### PR TITLE
[OPEN-STACK] Update to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "open-stack": {
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "repository": {
     "url": "https://github.com/klientjs/open-stack-cli.git",

--- a/src/__tests__/commands/badge/fixtures.ts
+++ b/src/__tests__/commands/badge/fixtures.ts
@@ -6,11 +6,11 @@ export const coverageSummary = path.join(tmpdir(), 'test-coverage-summary.json')
 export const badgeOutput = path.join(tmpdir(), 'test-badge.svg');
 
 export const createCoverageSummary = (
-  lines = 100,
-  statements = 100,
-  functions = 100,
-  branches = 100,
-  branchesTrue = 100
+  lines: string | number = 100,
+  statements: string | number = 100,
+  functions: string | number = 100,
+  branches: string | number = 100,
+  branchesTrue: string | number = 100
 ) => {
   fs.writeFileSync(
     coverageSummary,

--- a/src/__tests__/commands/badge/index.test.ts
+++ b/src/__tests__/commands/badge/index.test.ts
@@ -8,7 +8,8 @@ import {
   outputVerboseYellow,
   outputVerboseOrange,
   outputVerboseRed,
-  outputIncompleteVerbose
+  outputIncompleteVerbose,
+  outputVerboseUnknown
 } from './ouput';
 
 jest.useRealTimers();
@@ -149,5 +150,22 @@ test('badge:red', async () => {
   );
 
   expect(output).toBe(outputVerboseRed);
+  expect(code).toBe(0);
+});
+
+test('badge:empty', async () => {
+  createCoverageSummary('Unknown', 'Unknown', 'Unknown', 'Unknown');
+
+  const { code, output } = await runCommand(
+    'badge',
+    '--input',
+    coverageSummary,
+    '--output',
+    badgeOutput,
+    '--raw',
+    '--verbose'
+  );
+
+  expect(output).toBe(outputVerboseUnknown);
   expect(code).toBe(0);
 });

--- a/src/__tests__/commands/badge/ouput.ts
+++ b/src/__tests__/commands/badge/ouput.ts
@@ -94,3 +94,16 @@ export const outputVerboseRed = `[step] | Analyze coverage
 [info] | Make request to https://img.shields.io/badge/Coverage-50%25-red.svg
 [info] | Content uploaded in ${badgeOutput}
 [pass] | Successfully generated`;
+
+export const outputVerboseUnknown = `[step] | Analyze coverage
+[info] | Read ${coverageSummary}
+[info] | - lines: Unknown%
+[info] | - statements: Unknown%
+[info] | - functions: Unknown%
+[info] | - branches: Unknown%
+[info] | -----------------------
+[info] | TOTAL: 0%
+[step] | Create badge
+[info] | Make request to https://img.shields.io/badge/Coverage-0%25-red.svg
+[info] | Content uploaded in ${badgeOutput}
+[pass] | Successfully generated`;

--- a/src/commands/badge/middlewares/create.ts
+++ b/src/commands/badge/middlewares/create.ts
@@ -34,9 +34,13 @@ export default async (context: Context) => {
 
   let coverageValue = coverageData.total.statements.pct;
 
-  if (!incomplete) {
-    const coverageAmount = coverageMembers.map((n) => coverageData.total[n].pct).reduce((a, b) => a + b);
-    coverageValue = Math.round((coverageAmount / coverageMembers.length) * 100) / 100;
+  if (coverageValue !== 'Unknown') {
+    if (!incomplete) {
+      const coverageAmount = coverageMembers.map((n) => coverageData.total[n].pct).reduce((a, b) => a + b);
+      coverageValue = Math.round((coverageAmount / coverageMembers.length) * 100) / 100;
+    }
+  } else {
+    coverageValue = 0;
   }
 
   logger.info('-----------------------', 2);


### PR DESCRIPTION
# OpenStack update report ( [1.5.1](https://github.com/klientjs/open-stack/releases/tag/1.5.1) :arrow_right: [1.5.2](https://github.com/klientjs/open-stack/releases/tag/1.5.2) )

> Please check below the complete report which is a summary of changes made.
> It can help you to know what changes must be made manually.

## scripts

### :warning: CONFLICT

> This elements cannot be sync because they have been changed compared to open-stack version you are using.
> We strongly recommand you to update theses elements manually by comparing them with new version.

  - coverage:badge ([previous](https://github.com/klientjs/open-stack/tree/1.5.1/package.json)) ([current](https://github.com/klientjs/open-stack-cli/tree/main/package.json)) ([next](https://github.com/klientjs/open-stack/tree/1.5.2/package.json)) 

#### SKIPPED

  - lint
  - lint:fix
  - prettier
  - prettier:fix
  - test
  - dist
  - pre-commit
  - check
  - update:dependencies
  - update:open-stack
  - coverage:open
  - prepare
  - prepare:husky
  - prepare:pre-commit
  - prepare:commit-msg
  - release
  - configure

## devDependencies

#### SKIPPED

  - [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli)
  - [@commitlint/config-conventional](https://www.npmjs.com/package/@commitlint/config-conventional)
  - [@klient/open-stack-cli](https://www.npmjs.com/package/@klient/open-stack-cli)
  - [@release-it/conventional-changelog](https://www.npmjs.com/package/@release-it/conventional-changelog)
  - [@types/jest](https://www.npmjs.com/package/@types/jest)
  - [@types/node](https://www.npmjs.com/package/@types/node)
  - [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
  - [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
  - [auto-changelog](https://www.npmjs.com/package/auto-changelog)
  - [commitlint](https://www.npmjs.com/package/commitlint)
  - [conventional-changelog-conventionalcommits](https://www.npmjs.com/package/conventional-changelog-conventionalcommits)
  - [eslint](https://www.npmjs.com/package/eslint)
  - [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)
  - [eslint-config-airbnb-typescript](https://www.npmjs.com/package/eslint-config-airbnb-typescript)
  - [eslint-config-prettier](https://www.npmjs.com/package/eslint-config-prettier)
  - [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
  - [eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports)
  - [husky](https://www.npmjs.com/package/husky)
  - [jest](https://www.npmjs.com/package/jest)
  - [npm-check-updates](https://www.npmjs.com/package/npm-check-updates)
  - [prettier](https://www.npmjs.com/package/prettier)
  - [release-it](https://www.npmjs.com/package/release-it)
  - [ts-jest](https://www.npmjs.com/package/ts-jest)
  - [ts-node](https://www.npmjs.com/package/ts-node)
  - [tsutils](https://www.npmjs.com/package/tsutils)
  - [typescript](https://www.npmjs.com/package/typescript)

## Files

#### SKIPPED

  - .release-it.json
  - .eslintrc
  - .prettierrc
  - .editorconfig
  - .gitignore
  - .commitlintrc
  - jest.config.json
  - tsconfig.json
  - CODE_OF_CONDUCT.md
  - CONTRIBUTING.md
  - LICENCE
  - .github/PULL_REQUEST_TEMPLATE.md
  - .github/ISSUE_TEMPLATE/config.yml
  - .github/ISSUE_TEMPLATE/4_Help.yaml
  - .github/ISSUE_TEMPLATE/3_Documentation.yaml
  - .github/ISSUE_TEMPLATE/2_Feature_request.yaml
  - .github/ISSUE_TEMPLATE/1_Bug_report.yaml
  - .github/workflows/unpublish.yml
  - .github/workflows/tests.yml
  - .github/workflows/release.yml
  - .github/workflows/publish.yml
  - .github/workflows/open-stack.yml
  - .github/workflows/dependencies.yml
  - .github/workflows/cache.yml

*This message has been auto generated*